### PR TITLE
Provide height to the logo image tag

### DIFF
--- a/templates/_navbar_wagon.html.erb
+++ b/templates/_navbar_wagon.html.erb
@@ -1,7 +1,7 @@
 <div class="navbar-wagon">
   <!-- Logo -->
   <%= link_to root_path, class: "navbar-wagon-brand" do %>
-    <%= image_tag "logo.png" %>
+    <%= image_tag "logo.png", height: 50 %>
   <% end %>
 
   <!-- Right Navigation -->

--- a/templates/_navbar_wagon_without_login.html.erb
+++ b/templates/_navbar_wagon_without_login.html.erb
@@ -1,7 +1,7 @@
 <div class="navbar-wagon">
   <!-- Logo -->
   <%= link_to root_path, class: "navbar-wagon-brand" do %>
-    <%= image_tag "logo.png" %>
+    <%= image_tag "logo.png", height: 50 %>
   <% end %>
 
   <!-- Right Navigation -->


### PR DESCRIPTION
We should always provide a size to an image tag.
It also avoids having a huge logo displayed while loading the page and the CSS.

I've used the size defined here 👉  https://github.com/lewagon/ui-components/blob/master/source/stylesheets/components/_navbar.scss#L14-L16