### PR TITLE
Update drowndown links

### DIFF
--- a/templates/_navbar_wagon.html.erb
+++ b/templates/_navbar_wagon.html.erb
@@ -26,7 +26,7 @@
             </li>
             <li>
               <%= link_to "#" do %>
-                <i class="fa fa-home"></i>  <%= t(".profile", default: "Home") %>
+                <i class="fa fa-cog"></i>  <%= t(".settings", default: "Settings") %>
               <% end %>
             </li>
             <li>

--- a/templates/_navbar_wagon_without_login.html.erb
+++ b/templates/_navbar_wagon_without_login.html.erb
@@ -24,7 +24,7 @@
           </li>
           <li>
             <%= link_to "#" do %>
-              <i class="fa fa-home"></i>  <%= t(".profile", default: "Home") %>
+              <i class="fa fa-cog"></i>  <%= t(".settings", default: "Settings") %>
             <% end %>
           </li>
         </ul>


### PR DESCRIPTION
I propose to replace the `Home` link in the dropdown by a `Settings` link. 

People are used to click on the logo to get back to the homepage and we ofter see a `Settings` link instead of a `Home` link.

I also fixed the i18n key for this entry.
